### PR TITLE
Add custom source license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,9 @@
+Tool-Chest Source Code License
+
+Copyright (c) 2024 Tool-Chest
+
+Permission is granted to read the source code of this project for personal, educational, or reference purposes. You may copy small snippets of the code (up to 50 lines) into your own projects with attribution.
+
+You may not host, sell, distribute, or reproduce this project in full, nor may you create derivative works that replicate the entire website, without explicit written permission from the copyright holder.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ src/
 
 ## 📄 License
 
-This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
+This project is released under a custom Source Code License. You may read the code and copy small snippets, but hosting or redistributing the entire website is not allowed. See the [LICENSE](LICENSE) file for details.
 
 ## 🙏 Acknowledgments
 


### PR DESCRIPTION
## Summary
- add a custom Source Code License prohibiting hosting the whole site
- link README to the new LICENSE file

## Testing
- `npm run validate` *(fails: TypeScript errors)*

------
https://chatgpt.com/codex/tasks/task_e_683f500ffa688331b41faf009919ba29