### PR TITLE
Add header search routing and tests

### DIFF
--- a/src/app/__tests__/header.test.tsx
+++ b/src/app/__tests__/header.test.tsx
@@ -1,0 +1,42 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { Header } from "@/components/layout/Header";
+
+const pushMock = jest.fn();
+
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({
+    push: pushMock,
+    replace: jest.fn(),
+    prefetch: jest.fn(),
+    back: jest.fn(),
+    forward: jest.fn(),
+    refresh: jest.fn(),
+  }),
+  useSearchParams: () => new URLSearchParams(),
+  usePathname: () => "/",
+}));
+
+describe("Header search", () => {
+  it("navigates to search results on input", async () => {
+    const user = userEvent.setup();
+    render(<Header />);
+
+    const input = screen.getByRole("searchbox", { name: /search tools/i });
+    await user.type(input, "hash");
+
+    expect(pushMock).toHaveBeenLastCalledWith("/?query=hash");
+  });
+
+  it("clears search when input emptied", async () => {
+    const user = userEvent.setup();
+    render(<Header />);
+
+    const input = screen.getByRole("searchbox", { name: /search tools/i });
+    await user.type(input, "test");
+    pushMock.mockClear();
+
+    await user.clear(input);
+    expect(pushMock).toHaveBeenLastCalledWith("/");
+  });
+});

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import React, { useState, useEffect } from "react";
+import { useRouter } from "next/navigation";
 import Link from "next/link";
 import {
   MagnifyingGlassIcon,
@@ -18,6 +19,7 @@ export function Header({ className }: HeaderProps) {
   const [isScrolled, setIsScrolled] = useState(false);
   const [searchQuery, setSearchQuery] = useState("");
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
+  const router = useRouter();
 
   useEffect(() => {
     const handleScroll = () => {
@@ -51,8 +53,17 @@ export function Header({ className }: HeaderProps) {
   }, [isMobileMenuOpen]);
 
   const handleSearchChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setSearchQuery(e.target.value);
-    // TODO: Implement search functionality in Phase 3
+    const value = e.target.value;
+    setSearchQuery(value);
+
+    const trimmed = value.trim();
+    if (trimmed.length === 0) {
+      router.push("/");
+      return;
+    }
+
+    const query = encodeURIComponent(trimmed);
+    router.push(`/?query=${query}`);
   };
 
   const toggleMobileMenu = () => {


### PR DESCRIPTION
## Summary
- implement navigation-based search in Header component
- add tests for header search interaction

## Testing
- `npm test --silent` *(fails: Error validating datasource due to missing postgres configuration)*

------
https://chatgpt.com/codex/tasks/task_e_683f500b1c808331a9dc0dc1e2ff390c