### PR TITLE
Add unit tests for core hooks

### DIFF
--- a/src/hooks/__tests__/useClientErrorHandler.test.ts
+++ b/src/hooks/__tests__/useClientErrorHandler.test.ts
@@ -1,0 +1,32 @@
+import { renderHook, act } from "@testing-library/react";
+import { useClientErrorHandler } from "../useClientErrorHandler";
+
+jest.mock("@/utils/errors", () => ({
+  createClientError: jest.fn((err) => ({
+    message: err.message,
+    requestId: "1",
+  })),
+  categorizeError: jest.fn(() => "network"),
+  getUserFriendlyMessage: jest.fn(() => "Friendly"),
+  isRecoverableError: jest.fn(() => false),
+  logError: jest.fn(),
+}));
+
+jest.mock("@/components/ui/Toast", () => ({
+  createErrorToast: jest.fn((t, m) => ({ id: "1", title: t, message: m })),
+  createCriticalToast: jest.fn((t, m) => ({ id: "2", title: t, message: m })),
+  createWarningToast: jest.fn((t, m) => ({ id: "3", title: t, message: m })),
+}));
+
+describe("useClientErrorHandler", () => {
+  it("handles error and adds notification", async () => {
+    const { result } = renderHook(() => useClientErrorHandler());
+
+    await act(async () => {
+      await result.current.handleError(new Error("fail"));
+    });
+
+    expect(result.current.errors.length).toBe(1);
+    expect(result.current.notifications.length).toBe(1);
+  });
+});

--- a/src/hooks/__tests__/useLoadingManager.test.ts
+++ b/src/hooks/__tests__/useLoadingManager.test.ts
@@ -1,0 +1,25 @@
+import { renderHook, act } from "@testing-library/react";
+import { useLoadingManager } from "../useLoadingManager";
+
+describe("useLoadingManager", () => {
+  it("tracks loading states", () => {
+    const { result } = renderHook(() => useLoadingManager());
+
+    act(() => result.current.setLoading("fetch", true));
+    expect(result.current.isLoading("fetch")).toBe(true);
+    expect(result.current.isLoading()).toBe(true);
+
+    act(() => result.current.setLoading("fetch", false));
+    expect(result.current.isLoading()).toBe(false);
+  });
+
+  it("clears all states", () => {
+    const { result } = renderHook(() => useLoadingManager());
+    act(() => {
+      result.current.setLoading("a", true);
+      result.current.setLoading("b", true);
+    });
+    act(() => result.current.clearAll());
+    expect(result.current.isLoading()).toBe(false);
+  });
+});

--- a/src/hooks/__tests__/usePerformanceOptimization.test.ts
+++ b/src/hooks/__tests__/usePerformanceOptimization.test.ts
@@ -1,0 +1,29 @@
+import { renderHook, act } from "@testing-library/react";
+import { usePerformanceOptimization } from "../usePerformanceOptimization";
+
+describe("usePerformanceOptimization", () => {
+  it("tracks cache hits and misses", () => {
+    const { result } = renderHook(() => usePerformanceOptimization());
+    const cache = result.current.optimizeCache({ key: "tools" });
+
+    act(() => {
+      cache.trackCacheHit();
+      cache.trackCacheMiss();
+      cache.trackCacheHit();
+    });
+
+    const stats = result.current.getCacheStats();
+    const byKey = stats.byKey.find((s) => s.key === "tools");
+    expect(stats.overall.cacheHits).toBe(2);
+    expect(stats.overall.cacheMisses).toBe(1);
+    expect(byKey?.hits).toBe(2);
+    expect(byKey?.misses).toBe(1);
+  });
+
+  it("measures render performance", () => {
+    const { result } = renderHook(() => usePerformanceOptimization());
+    const measure = result.current.measureRenderPerformance("Test");
+    const time = measure.end();
+    expect(typeof time).toBe("number");
+  });
+});

--- a/src/hooks/__tests__/useTools.test.ts
+++ b/src/hooks/__tests__/useTools.test.ts
@@ -1,0 +1,41 @@
+import { renderHook } from "@testing-library/react";
+import useSWR from "swr";
+import { useTools, useToolsSearch } from "../useTools";
+import { swrFetcher } from "@/lib/api";
+
+jest.mock("swr", () => ({ __esModule: true, default: jest.fn() }));
+
+const mockUseSWR = useSWR as jest.Mock;
+
+describe("useTools", () => {
+  beforeEach(() => {
+    mockUseSWR.mockReset();
+  });
+
+  it("returns tools from swr", () => {
+    mockUseSWR.mockReturnValue({
+      data: [{ id: "1" }],
+      error: undefined,
+      isLoading: false,
+      mutate: jest.fn(),
+    });
+    const { result } = renderHook(() => useTools());
+    expect(result.current.tools).toHaveLength(1);
+    expect(mockUseSWR).toHaveBeenCalledWith("/tools", swrFetcher);
+  });
+
+  it("builds search endpoint", () => {
+    mockUseSWR.mockReturnValue({
+      data: [],
+      error: null,
+      isLoading: false,
+      mutate: jest.fn(),
+    });
+    renderHook(() => useToolsSearch("test"));
+    expect(mockUseSWR).toHaveBeenLastCalledWith(
+      "/tools/search?q=test",
+      swrFetcher,
+      { revalidateOnFocus: false, dedupingInterval: 300 },
+    );
+  });
+});

--- a/src/hooks/__tests__/useToolsWithState.test.ts
+++ b/src/hooks/__tests__/useToolsWithState.test.ts
@@ -1,0 +1,96 @@
+import { renderHook, act } from "@testing-library/react";
+import useSWR, { mutate as globalMutate } from "swr";
+import { useToolsWithState } from "../useToolsWithState";
+import { useToolFilterState } from "../useUrlState";
+import { swrFetcher } from "@/lib/api";
+
+jest.mock("swr", () => ({
+  __esModule: true,
+  default: jest.fn(),
+  mutate: jest.fn(),
+}));
+jest.mock("../useUrlState", () => ({ useToolFilterState: jest.fn() }));
+
+const mockUseSWR = useSWR as jest.Mock;
+const mockMutate = globalMutate as jest.Mock;
+const mockUseToolFilterState = useToolFilterState as jest.Mock;
+
+describe("useToolsWithState", () => {
+  beforeEach(() => {
+    mockUseSWR.mockReset();
+    mockMutate.mockReset();
+    mockUseToolFilterState.mockReset();
+  });
+
+  it("returns loading before mount", () => {
+    mockUseToolFilterState.mockReturnValue({
+      filterState: {
+        query: "",
+        tags: [],
+        sortBy: "displayOrder",
+        sortOrder: "asc",
+        page: 1,
+        limit: 24,
+      },
+      setQuery: jest.fn(),
+      setTags: jest.fn(),
+      setSorting: jest.fn(),
+      setPage: jest.fn(),
+      clearAllFilters: jest.fn(),
+      updateParams: jest.fn(),
+      mounted: false,
+    });
+    mockUseSWR.mockReturnValue({
+      data: [],
+      error: null,
+      isLoading: false,
+      mutate: jest.fn(),
+    });
+    const { result } = renderHook(() => useToolsWithState());
+    expect(result.current.isLoading).toBe(true);
+  });
+
+  it("builds endpoint and records usage", async () => {
+    const mutateMock = jest.fn();
+    mockUseToolFilterState.mockReturnValue({
+      filterState: {
+        query: "",
+        tags: [],
+        sortBy: "displayOrder",
+        sortOrder: "asc",
+        page: 1,
+        limit: 24,
+      },
+      setQuery: jest.fn(),
+      setTags: jest.fn(),
+      setSorting: jest.fn(),
+      setPage: jest.fn(),
+      clearAllFilters: jest.fn(),
+      updateParams: jest.fn(),
+      mounted: true,
+    });
+    mockUseSWR.mockReturnValue({
+      data: [{ slug: "t1" }],
+      error: null,
+      isLoading: false,
+      mutate: mutateMock,
+    });
+
+    global.fetch = jest.fn(() => Promise.resolve({ ok: true })) as any;
+    const { result } = renderHook(() => useToolsWithState());
+
+    expect(mockUseSWR).toHaveBeenCalledWith(
+      "/api/tools?limit=24",
+      swrFetcher,
+      expect.any(Object),
+    );
+
+    await act(async () => {
+      await result.current.actions.recordUsage("t1");
+    });
+
+    expect(global.fetch).toHaveBeenCalled();
+    expect(mutateMock).toHaveBeenCalled();
+    expect(mockMutate).toHaveBeenCalledWith("/api/tools?popular=true");
+  });
+});

--- a/src/hooks/__tests__/useUrlState.test.ts
+++ b/src/hooks/__tests__/useUrlState.test.ts
@@ -1,0 +1,51 @@
+import { renderHook, act, waitFor } from "@testing-library/react";
+import { useUrlState } from "../useUrlState";
+
+const pushMock = jest.fn();
+const replaceMock = jest.fn();
+let params = new URLSearchParams();
+
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({ push: pushMock, replace: replaceMock }),
+  useSearchParams: () => params,
+  usePathname: () => "/tools",
+}));
+
+describe("useUrlState", () => {
+  beforeEach(() => {
+    params = new URLSearchParams();
+    pushMock.mockClear();
+    replaceMock.mockClear();
+  });
+
+  it("returns default values when none in url", async () => {
+    const { result } = renderHook(() =>
+      useUrlState({ defaultValues: { page: "1" } }),
+    );
+
+    await waitFor(() => expect(result.current.mounted).toBe(true));
+    expect(result.current.urlState).toEqual({ page: "1" });
+  });
+
+  it("updates url params via setParam", async () => {
+    const { result } = renderHook(() =>
+      useUrlState({ defaultValues: { page: "1" } }),
+    );
+
+    await waitFor(() => expect(result.current.mounted).toBe(true));
+    act(() => result.current.setParam("page", "2"));
+
+    expect(pushMock).toHaveBeenCalledWith("/tools?page=2");
+  });
+
+  it("removes params when value is null", async () => {
+    params = new URLSearchParams("page=3");
+    const { result } = renderHook(() =>
+      useUrlState({ defaultValues: { page: "1" } }),
+    );
+    await waitFor(() => expect(result.current.mounted).toBe(true));
+
+    act(() => result.current.setParam("page", null));
+    expect(pushMock).toHaveBeenCalledWith("/tools");
+  });
+});


### PR DESCRIPTION
## Summary
- add tests for `useUrlState` URL sync
- add tests for loading manager and performance optimization hooks
- cover client error handling logic
- test tool fetching hooks

## Testing
- `npm run format`
- `npm run validate` *(fails: TS errors in existing files)*
- `npm test` *(fails: prisma migrate requires DATABASE_URL)*

------
https://chatgpt.com/codex/tasks/task_e_683f7d5f4f888331b4514a7efc4d6cb9