### PR TITLE
Add tests for service layer

### DIFF
--- a/tests/services/admin/adminTagService.test.ts
+++ b/tests/services/admin/adminTagService.test.ts
@@ -1,0 +1,27 @@
+import { PrismaClient } from "@prisma/client";
+import { AdminTagService } from "@/services/admin/adminTagService";
+
+const prisma = new PrismaClient({
+  datasources: { db: { url: "file:./test.db" } },
+});
+const service = new AdminTagService(prisma);
+
+afterAll(async () => {
+  await prisma.$disconnect();
+});
+
+describe("AdminTagService", () => {
+  test("generateSlugFromName converts names to slugs", () => {
+    expect(service.generateSlugFromName("Some Tag")).toBe("some-tag");
+  });
+
+  test("checkSlugAvailable detects existing slug", async () => {
+    const available = await service.checkSlugAvailable("encoding");
+    expect(available).toBe(false);
+  });
+
+  test("checkSlugAvailable allows new slug", async () => {
+    const available = await service.checkSlugAvailable("new-tag");
+    expect(available).toBe(true);
+  });
+});

--- a/tests/services/admin/adminToolService.test.ts
+++ b/tests/services/admin/adminToolService.test.ts
@@ -1,0 +1,27 @@
+import { PrismaClient } from "@prisma/client";
+import { AdminToolService } from "@/services/admin/adminToolService";
+
+const prisma = new PrismaClient({
+  datasources: { db: { url: "file:./test.db" } },
+});
+const service = new AdminToolService(prisma);
+
+afterAll(async () => {
+  await prisma.$disconnect();
+});
+
+describe("AdminToolService", () => {
+  test("generateSlugFromName converts names to slugs", () => {
+    expect(service.generateSlugFromName("My Tool Name")).toBe("my-tool-name");
+  });
+
+  test("checkSlugAvailable detects existing slug", async () => {
+    const available = await service.checkSlugAvailable("base64");
+    expect(available).toBe(false);
+  });
+
+  test("checkSlugAvailable allows new slug", async () => {
+    const available = await service.checkSlugAvailable("unique-slug");
+    expect(available).toBe(true);
+  });
+});

--- a/tests/services/admin/analyticsService.test.ts
+++ b/tests/services/admin/analyticsService.test.ts
@@ -1,0 +1,53 @@
+import { AnalyticsService } from "@/services/admin/analyticsService";
+
+describe("AnalyticsService utilities", () => {
+  let service: AnalyticsService;
+  beforeAll(() => {
+    jest
+      .spyOn(AnalyticsService.prototype as any, "initializeMonitoring")
+      .mockImplementation(() => {});
+    service = new AnalyticsService();
+  });
+
+  test("groupUsagesByPeriod groups by day", () => {
+    const usages = [
+      { timestamp: new Date("2024-01-01") },
+      { timestamp: new Date("2024-01-01") },
+      { timestamp: new Date("2024-01-02") },
+    ];
+    const result = (service as any).groupUsagesByPeriod(usages, "day");
+    expect(result).toEqual([2, 1]);
+  });
+
+  test("calculateGrowthRates returns percentages", () => {
+    const rates = (service as any).calculateGrowthRates({
+      daily: [1, 2, 4],
+      weekly: [2, 2],
+      monthly: [1, 3],
+    });
+    expect(Math.round(rates.dailyGrowth)).toBe(100);
+    expect(rates.weeklyGrowth).toBe(0);
+    expect(Math.round(rates.monthlyGrowth)).toBe(200);
+  });
+
+  test("calculateAlertSeverity maps ratios", () => {
+    const sevLow = (service as any).calculateAlertSeverity(
+      "error_rate",
+      100,
+      110,
+    );
+    const sevHigh = (service as any).calculateAlertSeverity(
+      "error_rate",
+      100,
+      220,
+    );
+    expect(sevLow).toBe("low");
+    expect(sevHigh).toBe("critical");
+  });
+
+  test("logError stores error entries", () => {
+    (service as any).errorLogs = [];
+    service.logError("boom", new Error("fail"));
+    expect((service as any).errorLogs.length).toBe(1);
+  });
+});

--- a/tests/services/admin/relationshipService.test.ts
+++ b/tests/services/admin/relationshipService.test.ts
@@ -1,0 +1,34 @@
+import { PrismaClient } from "@prisma/client";
+import { RelationshipService } from "@/services/admin/relationshipService";
+
+const prisma = new PrismaClient({
+  datasources: { db: { url: "file:./test.db" } },
+});
+const service = new RelationshipService(prisma);
+
+afterAll(async () => {
+  await prisma.$disconnect();
+});
+
+describe("RelationshipService", () => {
+  test("getAllRelationships returns all tool-tag pairs", async () => {
+    const relationships = await service.getAllRelationships();
+    expect(relationships.length).toBeGreaterThanOrEqual(7);
+  });
+
+  test("previewBulkOperation assign shows changes", async () => {
+    const tool = await prisma.tool.findFirst({
+      where: { slug: "markdown-to-pdf" },
+    });
+    const tag = await prisma.tag.findFirst({ where: { slug: "security" } });
+    const preview = await service.previewBulkOperation({
+      type: "assign",
+      toolIds: [tool!.id],
+      tagIds: [tag!.id],
+      requiresConfirmation: false,
+      estimatedChanges: 1,
+    });
+    expect(preview.summary.totalTools).toBe(1);
+    expect(preview.toolsToUpdate[0].addedTags.length).toBeGreaterThanOrEqual(1);
+  });
+});

--- a/tests/services/core/baseService.test.ts
+++ b/tests/services/core/baseService.test.ts
@@ -1,0 +1,50 @@
+import { BaseService, ServiceError } from "@/services/core/baseService";
+import { PrismaClient } from "@prisma/client";
+
+class DummyService extends BaseService {
+  constructor() {
+    super({} as PrismaClient);
+  }
+  public async getCachedPublic<T>(
+    key: string,
+    fn: () => Promise<T>,
+    ttl?: number,
+  ) {
+    return this.getCached(key, fn, ttl);
+  }
+  public invalidatePublic(pattern?: string) {
+    this.invalidateCache(pattern);
+  }
+  public validatePublic(params: Record<string, unknown>) {
+    this.validateRequired(params);
+  }
+}
+
+describe("BaseService", () => {
+  test("caches results from getCached", async () => {
+    const service = new DummyService();
+    const fetchFn = jest.fn().mockResolvedValue(42);
+    const first = await service.getCachedPublic("k", fetchFn);
+    const second = await service.getCachedPublic("k", fetchFn);
+    expect(first).toBe(42);
+    expect(second).toBe(42);
+    expect(fetchFn).toHaveBeenCalledTimes(1);
+  });
+
+  test("invalidateCache clears entries by pattern", async () => {
+    const service = new DummyService();
+    const fetchA = jest.fn().mockResolvedValue("a");
+    const fetchB = jest.fn().mockResolvedValue("b");
+    await service.getCachedPublic("foo:a", fetchA);
+    await service.getCachedPublic("foo:b", fetchB);
+    service.invalidatePublic("foo");
+    const fetchA2 = jest.fn().mockResolvedValue("a2");
+    await service.getCachedPublic("foo:a", fetchA2);
+    expect(fetchA2).toHaveBeenCalledTimes(1);
+  });
+
+  test("validateRequired throws ServiceError", () => {
+    const service = new DummyService();
+    expect(() => service.validatePublic({ name: "" })).toThrow(ServiceError);
+  });
+});

--- a/tests/services/core/serviceFactory.test.ts
+++ b/tests/services/core/serviceFactory.test.ts
@@ -1,0 +1,24 @@
+import { ServiceFactory, serviceFactory } from "@/services/core/serviceFactory";
+import { prisma } from "@/lib/prisma";
+
+class MockService {}
+
+describe("ServiceFactory", () => {
+  beforeEach(() => {
+    serviceFactory.clear();
+  });
+
+  test("register and retrieve singleton service", () => {
+    const factory = ServiceFactory.getInstance();
+    factory.register("mock", () => new MockService());
+    const one = factory.get<MockService>("mock");
+    const two = factory.get<MockService>("mock");
+    expect(one).toBeInstanceOf(MockService);
+    expect(one).toBe(two);
+  });
+
+  test("getPrisma returns shared instance", () => {
+    const factory = ServiceFactory.getInstance();
+    expect(factory.getPrisma()).toBe(prisma);
+  });
+});

--- a/tests/services/tools/toolService.test.ts
+++ b/tests/services/tools/toolService.test.ts
@@ -1,0 +1,43 @@
+import { PrismaClient } from "@prisma/client";
+import { ToolService } from "@/services/tools/toolService";
+
+const prisma = new PrismaClient({
+  datasources: { db: { url: "file:./test.db" } },
+});
+const service = new ToolService(prisma);
+
+afterAll(async () => {
+  await prisma.$disconnect();
+});
+
+describe("ToolService integration", () => {
+  test("getAllTools returns seeded tools", async () => {
+    const tools = await service.getAllTools();
+    expect(tools.length).toBeGreaterThanOrEqual(4);
+  });
+
+  test("getToolBySlug returns a tool", async () => {
+    const tool = await service.getToolBySlug("base64");
+    expect(tool?.slug).toBe("base64");
+  });
+
+  test("getToolsByTag returns tools for tag", async () => {
+    const tools = await service.getToolsByTag("development");
+    expect(tools.length).toBeGreaterThanOrEqual(4);
+  });
+
+  test("getAllTags returns seeded tags", async () => {
+    const tags = await service.getAllTags();
+    expect(tags.length).toBeGreaterThanOrEqual(4);
+  });
+
+  test("getTagBySlug returns tag", async () => {
+    const tag = await service.getTagBySlug("development");
+    expect(tag?.slug).toBe("development");
+  });
+
+  test("pagination works for tools", async () => {
+    const tools = await service.getToolsPaginated(0, 2);
+    expect(tools).toHaveLength(2);
+  });
+});


### PR DESCRIPTION
## Summary
- add Jest tests covering core services
- include integration tests against seeded prisma DB

## Testing
- `npm run lint`
- `npm run type-check` *(fails: provider mismatch errors)*
- `npm test` *(fails: prisma migrate deploy requires postgres connection)*

------
https://chatgpt.com/codex/tasks/task_e_683f7d812a5483319d81979a615d0d5e