### PR TITLE
Add missing component tests

### DIFF
--- a/src/components/admin/__tests__/AnalyticsDashboard.test.tsx
+++ b/src/components/admin/__tests__/AnalyticsDashboard.test.tsx
@@ -1,0 +1,27 @@
+import { render, screen } from "@testing-library/react";
+import { AnalyticsDashboard } from "../AnalyticsDashboard";
+import type { AnalyticsSummary } from "@/types/admin/analytics";
+
+describe("AnalyticsDashboard", () => {
+  const summary: AnalyticsSummary = {
+    totalTools: 1,
+    totalTags: 2,
+    totalUsage: 5,
+    activeUsers: 3,
+    topTools: [
+      { toolId: "1", name: "Test Tool", usageCount: 5, growthRate: 0 },
+    ],
+    recentActivity: [],
+    periodComparison: {
+      currentPeriod: { usage: 5, newUsers: 2, averageSessionTime: 1 },
+      previousPeriod: { usage: 3, newUsers: 1, averageSessionTime: 1 },
+      growthRates: { usageGrowth: 0, userGrowth: 0, sessionGrowth: 0 },
+    },
+  } as any;
+
+  it("renders summary stats", () => {
+    render(<AnalyticsDashboard initialData={summary} />);
+    expect(screen.getByText("Total Tools")).toBeInTheDocument();
+    expect(screen.getByText("1")).toBeInTheDocument();
+  });
+});

--- a/src/components/layout/__tests__/Footer.test.tsx
+++ b/src/components/layout/__tests__/Footer.test.tsx
@@ -1,0 +1,12 @@
+import { render, screen } from "@testing-library/react";
+import { Footer } from "../Footer";
+
+describe("Footer", () => {
+  it("renders current year", () => {
+    const year = new Date().getFullYear().toString();
+    render(<Footer />);
+    expect(
+      screen.getByText((content) => content.includes(year)),
+    ).toBeInTheDocument();
+  });
+});

--- a/src/components/layout/__tests__/Header.test.tsx
+++ b/src/components/layout/__tests__/Header.test.tsx
@@ -1,0 +1,36 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { Header } from "../Header";
+
+const pushMock = jest.fn();
+
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({
+    push: pushMock,
+    replace: jest.fn(),
+    prefetch: jest.fn(),
+    back: jest.fn(),
+    forward: jest.fn(),
+    refresh: jest.fn(),
+  }),
+  useSearchParams: () => new URLSearchParams(),
+  usePathname: () => "/",
+}));
+
+describe("Header mobile menu", () => {
+  it("toggles mobile menu", async () => {
+    const user = userEvent.setup();
+    render(<Header />);
+    const toggle = screen.getByRole("button", {
+      name: /open navigation menu/i,
+    });
+    await user.click(toggle);
+    expect(
+      screen.getByRole("dialog", { name: /mobile navigation menu/i }),
+    ).toBeInTheDocument();
+    await user.click(
+      screen.getByRole("button", { name: /close navigation menu/i }),
+    );
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+});

--- a/src/components/tools/__tests__/Base64Tool.test.tsx
+++ b/src/components/tools/__tests__/Base64Tool.test.tsx
@@ -1,0 +1,23 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { Base64Tool } from "../Base64Tool";
+import { Base64Service } from "@/services/tools/base64Service";
+
+jest.mock("@/services/tools/base64Service");
+
+const encodeMock = jest.mocked(Base64Service).encode as jest.Mock;
+const validateMock = jest.mocked(Base64Service).validateFile as jest.Mock;
+
+encodeMock.mockResolvedValue({ success: true, data: "YWJj" });
+validateMock.mockReturnValue({ isValid: true });
+
+describe("Base64Tool", () => {
+  it("encodes text input", async () => {
+    render(<Base64Tool />);
+    const textarea = screen.getByLabelText(/text input for encoding/i);
+    await userEvent.type(textarea, "abc");
+
+    await waitFor(() => expect(encodeMock).toHaveBeenCalled());
+    await screen.findByDisplayValue("YWJj");
+  });
+});

--- a/src/components/tools/__tests__/HashGeneratorTool.test.tsx
+++ b/src/components/tools/__tests__/HashGeneratorTool.test.tsx
@@ -1,0 +1,33 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { HashGeneratorTool } from "../HashGeneratorTool";
+import { HashGeneratorService } from "@/services/tools/hashGeneratorService";
+
+jest.mock("@/services/tools/hashGeneratorService");
+
+const genMock = jest.mocked(HashGeneratorService).generateHash as jest.Mock;
+const validateMock = jest.mocked(HashGeneratorService)
+  .validateFile as jest.Mock;
+
+genMock.mockResolvedValue({
+  success: true,
+  hash: "deadbeef",
+  algorithm: "SHA-256",
+  inputSize: 3,
+  processingTime: 1,
+});
+validateMock.mockReturnValue({ isValid: true });
+
+describe("HashGeneratorTool", () => {
+  it("generates hash for text", async () => {
+    jest.useFakeTimers();
+    render(<HashGeneratorTool />);
+    const textarea = screen.getByLabelText(/text input for hash generation/i);
+    await userEvent.type(textarea, "abc");
+    jest.runOnlyPendingTimers();
+
+    await waitFor(() => expect(genMock).toHaveBeenCalled());
+    expect(await screen.findByText(/SHA-256: deadbeef/i)).toBeInTheDocument();
+    jest.useRealTimers();
+  });
+});

--- a/src/components/ui/__tests__/Card.test.tsx
+++ b/src/components/ui/__tests__/Card.test.tsx
@@ -1,0 +1,35 @@
+import { render, screen } from "@testing-library/react";
+import { axe, toHaveNoViolations } from "jest-axe";
+import { Card, CardHeader, CardTitle, CardContent, CardFooter } from "../Card";
+
+expect.extend(toHaveNoViolations);
+
+describe("Card component", () => {
+  it("renders sections", () => {
+    render(
+      <Card>
+        <CardHeader>Head</CardHeader>
+        <CardTitle>Title</CardTitle>
+        <CardContent>Content</CardContent>
+        <CardFooter>Footer</CardFooter>
+      </Card>,
+    );
+    expect(screen.getByText("Head")).toBeInTheDocument();
+    expect(screen.getByText("Title")).toBeInTheDocument();
+    expect(screen.getByText("Content")).toBeInTheDocument();
+    expect(screen.getByText("Footer")).toBeInTheDocument();
+  });
+
+  it("has no accessibility violations", async () => {
+    const { container } = render(
+      <Card>
+        <CardHeader>Head</CardHeader>
+        <CardContent>Body</CardContent>
+      </Card>,
+    );
+    const results = await axe(container, {
+      rules: { region: { enabled: false } },
+    });
+    expect(results).toHaveNoViolations();
+  });
+});

--- a/src/components/ui/__tests__/Input.test.tsx
+++ b/src/components/ui/__tests__/Input.test.tsx
@@ -1,0 +1,40 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { axe, toHaveNoViolations } from "jest-axe";
+import { Input } from "../Input";
+
+expect.extend(toHaveNoViolations);
+
+describe("Input component", () => {
+  it("renders label and associates input", () => {
+    render(<Input label="Name" />);
+    const input = screen.getByLabelText(/name/i);
+    expect(input).toBeInTheDocument();
+  });
+
+  it("shows error state", () => {
+    render(<Input label="Email" error="Required" />);
+    expect(screen.getByText("Required")).toBeInTheDocument();
+    const input = screen.getByLabelText(/email/i);
+    expect(input).toHaveAttribute("aria-invalid", "true");
+  });
+
+  it("supports helper text", () => {
+    render(<Input label="Email" helperText="We'll never share" />);
+    expect(screen.getByText(/never share/i)).toBeInTheDocument();
+  });
+
+  it("is marked required", () => {
+    render(<Input label="Username" isRequired />);
+    const star = screen.getByLabelText(/required/);
+    expect(star).toBeInTheDocument();
+  });
+
+  it("has no accessibility violations", async () => {
+    const { container } = render(<Input label="Email" />);
+    const results = await axe(container, {
+      rules: { region: { enabled: false } },
+    });
+    expect(results).toHaveNoViolations();
+  });
+});

--- a/src/components/ui/__tests__/ProgressIndicator.test.tsx
+++ b/src/components/ui/__tests__/ProgressIndicator.test.tsx
@@ -1,0 +1,28 @@
+import { render, screen } from "@testing-library/react";
+import { axe, toHaveNoViolations } from "jest-axe";
+import { ProgressIndicator } from "../ProgressIndicator";
+import type { Base64Progress } from "@/types/tools/base64";
+
+expect.extend(toHaveNoViolations);
+
+describe("ProgressIndicator", () => {
+  const progress: Base64Progress = {
+    stage: "processing",
+    progress: 50,
+    bytesProcessed: 512,
+    totalBytes: 1024,
+    estimatedTimeRemaining: 10,
+  };
+
+  it("renders progress information", () => {
+    render(<ProgressIndicator progress={progress} />);
+    expect(screen.getByText(/processing data/i)).toBeInTheDocument();
+    expect(screen.getByText(/50%/i)).toBeInTheDocument();
+  });
+
+  it("has no accessibility violations", async () => {
+    const { container } = render(<ProgressIndicator progress={progress} />);
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+});

--- a/src/components/ui/__tests__/Toast.test.tsx
+++ b/src/components/ui/__tests__/Toast.test.tsx
@@ -1,0 +1,37 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { axe, toHaveNoViolations } from "jest-axe";
+import { Toast } from "../Toast";
+import type { ErrorNotification } from "@/types/errors";
+
+expect.extend(toHaveNoViolations);
+
+describe("Toast component", () => {
+  const notification: ErrorNotification = {
+    id: "1",
+    type: "toast",
+    severity: "low",
+    title: "Hello",
+    message: "World",
+    dismissible: true,
+  };
+
+  it("renders message and dismisses", async () => {
+    const onDismiss = jest.fn();
+    const user = userEvent.setup();
+    render(<Toast notification={notification} onDismiss={onDismiss} />);
+
+    expect(screen.getByText(/world/i)).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /dismiss/i }));
+    expect(onDismiss).toHaveBeenCalledWith("1");
+  });
+
+  it("has no accessibility violations", async () => {
+    const { container } = render(
+      <Toast notification={notification} onDismiss={jest.fn()} />,
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+});


### PR DESCRIPTION
## Summary
- add tests for Input, Card, Toast and ProgressIndicator components
- cover Base64Tool and HashGeneratorTool with mocked service tests
- test AnalyticsDashboard summary rendering
- test Header mobile menu toggle and Footer year display

## Testing
- `npm test` *(fails: Prisma setup requires DB)*

------
https://chatgpt.com/codex/tasks/task_e_683f7d9b228c8331bf45aa15a89cfe85