### PR TITLE
Fix ESLint compile errors

### DIFF
--- a/src/components/tools/__tests__/Base64Tool.test.tsx
+++ b/src/components/tools/__tests__/Base64Tool.test.tsx
@@ -11,11 +11,11 @@ jest.mock("@/services/tools/base64Service", () => ({
     copyToClipboard: jest.fn(),
     trackUsage: jest.fn(),
     downloadAsFile: jest.fn(),
-  }
+  },
 }));
 
-// Import the mocked service
-const { Base64Service } = require("@/services/tools/base64Service");
+// Import the mocked service using ES module syntax
+import { Base64Service } from "@/services/tools/base64Service";
 const encodeMock = Base64Service.encode as jest.Mock;
 const validateMock = Base64Service.validateFile as jest.Mock;
 const copyMock = Base64Service.copyToClipboard as jest.Mock;
@@ -26,16 +26,16 @@ encodeMock.mockResolvedValue({
   success: true,
   data: "YWJj",
   processingTime: 1,
-  warnings: []
+  warnings: [],
 });
 validateMock.mockReturnValue({
   isValid: true,
   warnings: [],
-  validationErrors: []
+  validationErrors: [],
 });
 copyMock.mockResolvedValue({
   success: true,
-  message: "Copied to clipboard"
+  message: "Copied to clipboard",
 });
 trackUsageMock.mockResolvedValue(undefined);
 
@@ -51,11 +51,16 @@ describe("Base64Tool", () => {
     const textarea = screen.getByLabelText(/text input/i);
     await userEvent.type(textarea, "abc");
 
-    await waitFor(() => expect(encodeMock).toHaveBeenCalled(), { timeout: 3000 });
+    await waitFor(() => expect(encodeMock).toHaveBeenCalled(), {
+      timeout: 3000,
+    });
 
     // Look for the result in the output area instead of display value
-    await waitFor(() => {
-      expect(screen.getByText(/YWJj/)).toBeInTheDocument();
-    }, { timeout: 3000 });
+    await waitFor(
+      () => {
+        expect(screen.getByText(/YWJj/)).toBeInTheDocument();
+      },
+      { timeout: 3000 },
+    );
   });
 });

--- a/src/components/tools/__tests__/HashGeneratorTool.test.tsx
+++ b/src/components/tools/__tests__/HashGeneratorTool.test.tsx
@@ -10,11 +10,11 @@ jest.mock("@/services/tools/hashGeneratorService", () => ({
     copyToClipboard: jest.fn(),
     trackUsage: jest.fn(),
     downloadAsFile: jest.fn(),
-  }
+  },
 }));
 
-// Import the mocked service
-const { HashGeneratorService } = require("@/services/tools/hashGeneratorService");
+// Import the mocked service using ES module syntax
+import { HashGeneratorService } from "@/services/tools/hashGeneratorService";
 const genMock = HashGeneratorService.generateHash as jest.Mock;
 const validateMock = HashGeneratorService.validateFile as jest.Mock;
 const trackUsageMock = HashGeneratorService.trackUsage as jest.Mock;
@@ -27,17 +27,17 @@ genMock.mockResolvedValue({
   algorithm: "SHA-256",
   inputSize: 3,
   processingTime: 1,
-  warnings: []
+  warnings: [],
 });
 validateMock.mockReturnValue({
   isValid: true,
   warnings: [],
-  validationErrors: []
+  validationErrors: [],
 });
 trackUsageMock.mockResolvedValue(undefined);
 copyMock.mockResolvedValue({
   success: true,
-  message: "Copied to clipboard"
+  message: "Copied to clipboard",
 });
 
 describe("HashGeneratorTool", () => {
@@ -56,8 +56,11 @@ describe("HashGeneratorTool", () => {
     await waitFor(() => expect(genMock).toHaveBeenCalled(), { timeout: 5000 });
 
     // Look for the hash result in the component
-    await waitFor(() => {
-      expect(screen.getByText(/deadbeef/i)).toBeInTheDocument();
-    }, { timeout: 5000 });
+    await waitFor(
+      () => {
+        expect(screen.getByText(/deadbeef/i)).toBeInTheDocument();
+      },
+      { timeout: 5000 },
+    );
   });
 });

--- a/src/components/ui/__tests__/Input.test.tsx
+++ b/src/components/ui/__tests__/Input.test.tsx
@@ -1,5 +1,4 @@
 import { render, screen } from "@testing-library/react";
-import userEvent from "@testing-library/user-event";
 import { axe, toHaveNoViolations } from "jest-axe";
 import { Input } from "../Input";
 

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -7,40 +7,45 @@ import { PrismaClient } from "@prisma/client";
 
 // Global Prisma instance to prevent multiple connections
 declare global {
-    var __prisma: PrismaClient | undefined;
+  // eslint-disable-next-line no-var
+  var __prisma: PrismaClient | undefined;
 }
 
 /**
  * Get database configuration based on environment
  */
 function getDatabaseConfig() {
-    const isTest = process.env.NODE_ENV === "test";
-    const provider = process.env.DATABASE_PROVIDER || (isTest ? "sqlite" : "postgresql");
-    const url = process.env.DATABASE_URL || (isTest ? "file:./test.db" : "");
+  const isTest = process.env.NODE_ENV === "test";
+  const provider =
+    process.env.DATABASE_PROVIDER || (isTest ? "sqlite" : "postgresql");
+  const url = process.env.DATABASE_URL || (isTest ? "file:./test.db" : "");
 
-    if (!url) {
-        throw new Error("DATABASE_URL environment variable is required");
-    }
+  if (!url) {
+    throw new Error("DATABASE_URL environment variable is required");
+  }
 
-    return { provider, url };
+  return { provider, url };
 }
 
 /**
  * Create Prisma client with environment-appropriate configuration
  */
 function createPrismaClient(): PrismaClient {
-    const config = getDatabaseConfig();
+  const config = getDatabaseConfig();
 
-    console.log(`🗄️  Connecting to ${config.provider} database`);
+  console.log(`🗄️  Connecting to ${config.provider} database`);
 
-    return new PrismaClient({
-        datasources: {
-            db: {
-                url: config.url,
-            },
-        },
-        log: process.env.NODE_ENV === "development" ? ["query", "error", "warn"] : ["error"],
-    });
+  return new PrismaClient({
+    datasources: {
+      db: {
+        url: config.url,
+      },
+    },
+    log:
+      process.env.NODE_ENV === "development"
+        ? ["query", "error", "warn"]
+        : ["error"],
+  });
 }
 
 /**
@@ -48,17 +53,17 @@ function createPrismaClient(): PrismaClient {
  * Uses singleton pattern to prevent multiple connections
  */
 export function getPrismaClient(): PrismaClient {
-    if (global.__prisma) {
-        return global.__prisma;
-    }
+  if (global.__prisma) {
+    return global.__prisma;
+  }
 
-    const prisma = createPrismaClient();
+  const prisma = createPrismaClient();
 
-    if (process.env.NODE_ENV !== "production") {
-        global.__prisma = prisma;
-    }
+  if (process.env.NODE_ENV !== "production") {
+    global.__prisma = prisma;
+  }
 
-    return prisma;
+  return prisma;
 }
 
 /**
@@ -70,10 +75,10 @@ export const prisma = getPrismaClient();
  * Cleanup function for tests
  */
 export async function cleanupDatabase() {
-    if (process.env.NODE_ENV === "test") {
-        await prisma.$disconnect();
-        if (global.__prisma) {
-            global.__prisma = undefined;
-        }
+  if (process.env.NODE_ENV === "test") {
+    await prisma.$disconnect();
+    if (global.__prisma) {
+      global.__prisma = undefined;
     }
-} 
+  }
+}


### PR DESCRIPTION
## Summary
- use ES module imports in Base64Tool and HashGeneratorTool tests
- remove unused `userEvent` import in `Input.test`
- suppress `no-var` rule for global prisma instance

## Testing
- `npm run lint`
- `npm run type-check` *(fails: Type errors in services/tools/toolService.ts)*
- `npm test` *(fails: several test suites)*

------
https://chatgpt.com/codex/tasks/task_e_6840922d3b0883318b436d253bac399f