### PR TITLE
Fix lint warnings for admin services

### DIFF
--- a/src/services/admin/analyticsService.ts
+++ b/src/services/admin/analyticsService.ts
@@ -245,7 +245,7 @@ export class AnalyticsService extends BaseService {
   public logError(
     message: string,
     error: Error,
-    metadata: Record<string, any> = {},
+    metadata: Record<string, unknown> = {},
   ): void {
     const errorEntry: ErrorLogEntry = {
       id: `error_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`,
@@ -496,7 +496,7 @@ export class AnalyticsService extends BaseService {
     const cleanup = () => {
       const cutoffDate = new Date(
         Date.now() -
-        this.monitoringConfig.retentionPeriod * 24 * 60 * 60 * 1000,
+          this.monitoringConfig.retentionPeriod * 24 * 60 * 60 * 1000,
       );
 
       // Clean up old error logs
@@ -836,7 +836,7 @@ export class AnalyticsService extends BaseService {
       timestamp: usage.timestamp,
       action: "tool_used",
       toolName: usage.tool.name,
-      metadata: (usage.metadata as Record<string, any>) || {},
+      metadata: (usage.metadata as Record<string, unknown>) || {},
     }));
   }
 
@@ -910,7 +910,7 @@ export class AnalyticsService extends BaseService {
   }
 
   private groupUsagesByPeriod(
-    usages: any[],
+    usages: Array<{ timestamp: Date }>,
     period: "day" | "week" | "month",
   ): number[] {
     // Simple implementation - group usages by period and count

--- a/src/services/admin/relationshipService.ts
+++ b/src/services/admin/relationshipService.ts
@@ -1,4 +1,4 @@
-import { PrismaClient } from "@prisma/client";
+import { PrismaClient, Prisma } from "@prisma/client";
 import { BaseService } from "../core/baseService";
 import {
   ToolTagRelationship,
@@ -71,7 +71,7 @@ export class RelationshipService
 
     return this.getCached(cacheKey, async () => {
       // Build where clause
-      const where: any = {};
+      const where: Prisma.ToolTagWhereInput = {};
 
       if (filters.toolIds && filters.toolIds.length > 0) {
         where.toolId = { in: filters.toolIds };
@@ -93,7 +93,7 @@ export class RelationshipService
       }
 
       // Build order by
-      let orderBy: any = {};
+      let orderBy: Prisma.ToolTagOrderByWithRelationInput = {};
       switch (sortOptions.field) {
         case "toolName":
           orderBy = { tool: { name: sortOptions.direction } };


### PR DESCRIPTION
## Summary
- remove explicit `any` in analytics service
- remove explicit `any` in relationship service

## Testing
- `npm run validate` *(fails: code style issues found in other files)*
- `npm test` *(fails: 9 failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_6840994420d88331bfefda0c9c4c3162