### PR TITLE
Fix lint issues in admin types and utils

### DIFF
--- a/src/types/admin/relationship.ts
+++ b/src/types/admin/relationship.ts
@@ -147,7 +147,7 @@ export interface MultiSelectOption {
   description?: string;
   color?: string;
   isActive?: boolean;
-  metadata?: Record<string, any>;
+  metadata?: Record<string, unknown>;
 }
 
 export interface MultiSelectState {

--- a/src/utils/errors/index.ts
+++ b/src/utils/errors/index.ts
@@ -193,8 +193,16 @@ export function getUserFriendlyMessage(error: Error): string {
 /**
  * Log error to console with structured format
  */
-export function logError(error: Error, context?: Record<string, any>) {
-  const errorData = createStandardError(error, context);
+export function logError(error: Error, context?: unknown) {
+  const errorData = createStandardError(
+    error,
+    context as {
+      component?: string;
+      path?: string;
+      userId?: string;
+      requestId?: string;
+    },
+  );
 
   console.error("Error occurred:", {
     ...errorData,

--- a/src/utils/validation/index.ts
+++ b/src/utils/validation/index.ts
@@ -10,11 +10,9 @@ export function isEmail(value: string): boolean {
  */
 export function isUrl(value: string): boolean {
   try {
-    // eslint-disable-next-line no-new
     new URL(value);
     return true;
   } catch {
     return false;
   }
 }
-


### PR DESCRIPTION
## Summary
- avoid explicit any in MultiSelectOption
- improve logError context typing
- remove unused eslint directive in validation

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run test:quick -- -t "classNames"`

------
https://chatgpt.com/codex/tasks/task_e_684098f511948331862b35688295f658