### PR TITLE
Fix lint warnings in services

### DIFF
--- a/src/services/tools/faviconGeneratorService.ts
+++ b/src/services/tools/faviconGeneratorService.ts
@@ -18,6 +18,13 @@ import {
   PERFORMANCE_THRESHOLDS,
 } from "@/types/tools/faviconGenerator";
 
+interface WebAppManifestIcon {
+  src: string;
+  sizes: string;
+  type: string;
+  purpose?: string;
+}
+
 /**
  * Service for client-side favicon generation using Canvas API with enhanced performance features
  */
@@ -934,12 +941,12 @@ export class FaviconGeneratorService {
    * Generate comprehensive web app manifest.json
    */
   private static generateWebAppManifest(favicons: GeneratedFavicon[]): string {
-    const icons = favicons
+    const icons: WebAppManifestIcon[] = favicons
       .filter(
         (favicon) => favicon.size.format === "png" && favicon.size.width >= 192,
       )
       .map((favicon) => {
-        const icon: any = {
+        const icon: WebAppManifestIcon = {
           src: `/${favicon.filename}`,
           sizes: `${favicon.size.width}x${favicon.size.height}`,
           type: "image/png",

--- a/src/services/tools/hashGeneratorService.ts
+++ b/src/services/tools/hashGeneratorService.ts
@@ -3,6 +3,7 @@ import {
   HashValidationResult,
   HashOperationParams,
   HashUsageMetrics,
+  HashProgress,
   ALGORITHM_INFO,
   FILE_SIZE_LIMITS,
   ALL_ALLOWED_FILE_TYPES,
@@ -338,7 +339,9 @@ export class HashGeneratorService {
     const fileExtension = file.name.split(".").pop()?.toLowerCase();
 
     if (file.type) {
-      const isAllowed = ALL_ALLOWED_FILE_TYPES.includes(file.type as any);
+      const isAllowed = ALL_ALLOWED_FILE_TYPES.includes(
+        file.type as (typeof ALL_ALLOWED_FILE_TYPES)[number],
+      );
       const category =
         FILE_TYPE_CATEGORIES[file.type as keyof typeof FILE_TYPE_CATEGORIES];
 
@@ -614,7 +617,7 @@ export class HashGeneratorService {
    */
   private static async readFileWithProgress(
     file: File,
-    onProgress?: (progress: any) => void,
+    onProgress?: (progress: HashProgress) => void,
   ): Promise<Uint8Array> {
     return new Promise((resolve, reject) => {
       const reader = new FileReader();


### PR DESCRIPTION
## Summary
- address ESLint `no-explicit-any` warnings in tool services
- type the task-lists plugin in markdown service
- add WebAppManifestIcon type and use it
- improve progress typing for HashGeneratorService

## Testing
- `npm run validate` *(fails: Code style issues found in 69 files)*
- `npm run test:quick` *(fails: 8 test suites failed)*

------
https://chatgpt.com/codex/tasks/task_e_684099360a808331a8a984280ed3b037