### PR TITLE
Fix lint errors by removing any

### DIFF
--- a/src/components/ui/SuspenseFallback.tsx
+++ b/src/components/ui/SuspenseFallback.tsx
@@ -264,10 +264,13 @@ export function FormFallback({
 }
 
 // Higher-order component for wrapping components with suspense
-export function withSuspense<P extends object>(
+export function withSuspense<
+  P extends object,
+  FProps extends object = Record<string, unknown>,
+>(
   Component: React.ComponentType<P>,
-  fallback?: React.ComponentType<any>,
-  fallbackProps?: any,
+  fallback?: React.ComponentType<FProps>,
+  fallbackProps?: FProps,
 ) {
   const WrappedComponent = (props: P) => (
     <React.Suspense

--- a/src/hooks/__tests__/useToolsWithState.test.ts
+++ b/src/hooks/__tests__/useToolsWithState.test.ts
@@ -76,7 +76,10 @@ describe("useToolsWithState", () => {
       mutate: mutateMock,
     });
 
-    global.fetch = jest.fn(() => Promise.resolve({ ok: true })) as any;
+    const fetchMock: jest.MockedFunction<typeof fetch> = jest
+      .fn()
+      .mockResolvedValue(new Response(null, { status: 200 }));
+    global.fetch = fetchMock;
     const { result } = renderHook(() => useToolsWithState());
 
     expect(mockUseSWR).toHaveBeenCalledWith(

--- a/src/hooks/usePerformanceOptimization.ts
+++ b/src/hooks/usePerformanceOptimization.ts
@@ -22,6 +22,14 @@ export interface CacheStrategy {
   strategy?: "cache-first" | "network-first" | "cache-only" | "network-only";
 }
 
+export interface WebVitalsReportMetric {
+  name: string;
+  value: number;
+  delta?: number;
+  id: string;
+  entries?: PerformanceEntry[];
+}
+
 export function usePerformanceOptimization() {
   const [metrics, setMetrics] = useState<PerformanceMetrics>({
     loadTime: 0,
@@ -256,7 +264,7 @@ export function usePerformanceOptimization() {
   }, [metrics]);
 
   // Report Core Web Vitals
-  const reportWebVitals = useCallback((metric: any) => {
+  const reportWebVitals = useCallback((metric: WebVitalsReportMetric) => {
     // Log to console in development
     if (process.env.NODE_ENV === "development") {
       console.log(`[Performance] ${metric.name}:`, metric.value, metric);


### PR DESCRIPTION
## Summary
- remove `any` usage in `NetworkErrorHandler`
- type `withSuspense` HOC generically
- create specific metric type in `usePerformanceOptimization`
- update unit test to mock fetch without `any`

## Testing
- `npm run validate` *(fails: Code style issues found in 69 files)*

------
https://chatgpt.com/codex/tasks/task_e_684099861b588331b6ea410db2c074fc