### PR TITLE
Fix lint warnings for analytics routes

### DIFF
--- a/src/app/api/admin/analytics/system/route.ts
+++ b/src/app/api/admin/analytics/system/route.ts
@@ -1,5 +1,10 @@
 import { NextRequest, NextResponse } from "next/server";
 import { AnalyticsService } from "@/services/admin/analyticsService";
+import type {
+  SystemHealthDashboard,
+  SystemPerformanceMetrics,
+  RealTimeMetrics,
+} from "@/types/admin/analytics";
 
 const analyticsService = AnalyticsService.getInstance();
 
@@ -73,7 +78,9 @@ export async function GET(request: NextRequest) {
     const detailed = searchParams.get("detailed") === "true";
     const includeHistory = searchParams.get("includeHistory") === "true";
 
-    let systemMetrics;
+    let systemMetrics: (SystemHealthDashboard | SystemPerformanceMetrics) & {
+      metricsHistory?: RealTimeMetrics[];
+    };
 
     if (detailed) {
       // Get comprehensive system health dashboard
@@ -86,7 +93,7 @@ export async function GET(request: NextRequest) {
     // Add real-time metrics if requested
     if (includeHistory) {
       const metricsHistory = await analyticsService.getRealTimeMetrics(100);
-      (systemMetrics as any).metricsHistory = metricsHistory;
+      systemMetrics = { ...systemMetrics, metricsHistory };
     }
 
     const current = requestCounts.get(clientIP);


### PR DESCRIPTION
## Summary
- replace `any` usage in admin analytics API routes with explicit types

## Testing
- `npm run format` *(passes)*
- `npm run validate` *(fails: Code style issues found)*
- `npm test` *(fails: failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_684099edc5e083318981540f77bb7e8f