### PR TITLE
Fix lint warnings

### DIFF
--- a/src/app/api/tools/base64/usage/route.ts
+++ b/src/app/api/tools/base64/usage/route.ts
@@ -165,37 +165,39 @@ export async function GET(request: NextRequest) {
     }
 
     // Calculate basic statistics
-    const toolStats = Array.isArray(tool.toolUsageStats) ? tool.toolUsageStats[0] : tool.toolUsageStats;
+    const toolStats = Array.isArray(tool.toolUsageStats)
+      ? tool.toolUsageStats[0]
+      : tool.toolUsageStats;
     const stats = {
       totalUsages: toolStats?.usageCount || 0,
       recentUsageCount: recentUsages.length,
       lastUsed: toolStats?.lastUsed || null,
       operations: {
         encode: recentUsages.filter(
-          (u: any) => (u.metadata as UsageMetadata)?.operation === "encode",
+          (u) => (u.metadata as UsageMetadata)?.operation === "encode",
         ).length,
         decode: recentUsages.filter(
-          (u: any) => (u.metadata as UsageMetadata)?.operation === "decode",
+          (u) => (u.metadata as UsageMetadata)?.operation === "decode",
         ).length,
       },
       inputTypes: {
         text: recentUsages.filter(
-          (u: any) => (u.metadata as UsageMetadata)?.inputType === "text",
+          (u) => (u.metadata as UsageMetadata)?.inputType === "text",
         ).length,
         file: recentUsages.filter(
-          (u: any) => (u.metadata as UsageMetadata)?.inputType === "file",
+          (u) => (u.metadata as UsageMetadata)?.inputType === "file",
         ).length,
       },
       performance: {
         averageProcessingTime:
           recentUsages.reduce(
-            (sum: number, u: any) =>
+            (sum: number, u) =>
               sum + ((u.metadata as UsageMetadata)?.processingTime || 0),
             0,
           ) / recentUsages.length || 0,
         successRate:
           recentUsages.filter(
-            (u: any) => (u.metadata as UsageMetadata)?.success === true,
+            (u) => (u.metadata as UsageMetadata)?.success === true,
           ).length / recentUsages.length || 0,
       },
     };

--- a/src/app/debug/page.tsx
+++ b/src/app/debug/page.tsx
@@ -9,7 +9,9 @@ import { ApiResponse } from "@/types/api/common";
 export default function DebugPage() {
   const [mounted, setMounted] = useState(false);
   const [simpleClientTest, setSimpleClientTest] = useState("not set");
-  const [directApiData, setDirectApiData] = useState<any>(null);
+  const [directApiData, setDirectApiData] = useState<ApiResponse<
+    ToolDTO[]
+  > | null>(null);
   const [directApiError, setDirectApiError] = useState<string | null>(null);
 
   // Simple client-side test to verify React hydration
@@ -20,10 +22,11 @@ export default function DebugPage() {
   }, []);
 
   // Test SWR directly
-  const { data: swrData, error: swrError, isLoading: swrLoading } = useSWR<ApiResponse<ToolDTO[]>>(
-    "/api/tools",
-    swrFetcher
-  );
+  const {
+    data: swrData,
+    error: swrError,
+    isLoading: swrLoading,
+  } = useSWR<ApiResponse<ToolDTO[]>>("/api/tools", swrFetcher);
 
   // Direct API test effect
   useEffect(() => {
@@ -47,7 +50,9 @@ export default function DebugPage() {
 
       <h2>Direct API Call</h2>
       <pre>{JSON.stringify(directApiData, null, 2)}</pre>
-      {directApiError && <p style={{ color: "red" }}>Error: {directApiError}</p>}
+      {directApiError && (
+        <p style={{ color: "red" }}>Error: {directApiError}</p>
+      )}
 
       <h2>SWR Test</h2>
       <div>

--- a/src/components/admin/AnalyticsDashboard.tsx
+++ b/src/components/admin/AnalyticsDashboard.tsx
@@ -8,8 +8,15 @@ import type {
   AnalyticsSummary,
   AnalyticsChart as AnalyticsChartType,
   SystemPerformanceMetrics,
+  RealTimeMetrics,
   AnalyticsDashboardProps,
 } from "@/types/admin/analytics";
+
+type ExtendedSystemMetrics = SystemPerformanceMetrics & {
+  cpuUsage?: number;
+  uptime?: number;
+  metrics?: RealTimeMetrics;
+};
 
 export function AnalyticsDashboard({ initialData }: AnalyticsDashboardProps) {
   const [summary, setSummary] = useState<AnalyticsSummary | null>(
@@ -17,7 +24,7 @@ export function AnalyticsDashboard({ initialData }: AnalyticsDashboardProps) {
   );
   const [charts, setCharts] = useState<AnalyticsChartType[]>([]);
   const [systemMetrics, setSystemMetrics] =
-    useState<SystemPerformanceMetrics | null>(null);
+    useState<ExtendedSystemMetrics | null>(null);
   const [loading, setLoading] = useState(!initialData);
   const [error, setError] = useState<string | null>(null);
 
@@ -174,6 +181,11 @@ export function AnalyticsDashboard({ initialData }: AnalyticsDashboardProps) {
       </div>
     );
   }
+
+  const uptime = systemMetrics.uptime ?? systemMetrics.systemHealth.uptime;
+
+  const cpuUsage =
+    systemMetrics.cpuUsage ?? systemMetrics.metrics?.cpuUsage ?? 0;
 
   return (
     <div className="space-y-8">
@@ -349,7 +361,7 @@ export function AnalyticsDashboard({ initialData }: AnalyticsDashboardProps) {
                   Uptime
                 </span>
                 <span className="text-sm font-mono text-success-600 dark:text-success-400">
-                  {formatUptime((systemMetrics as any).uptime || 86400)}
+                  {formatUptime(uptime || 86400)}
                 </span>
               </div>
               <div className="w-full bg-neutral-200 dark:bg-neutral-700 rounded-full h-2">
@@ -398,19 +410,19 @@ export function AnalyticsDashboard({ initialData }: AnalyticsDashboardProps) {
                   CPU
                 </span>
                 <span className="text-sm font-mono text-neutral-600 dark:text-neutral-400">
-                  {((systemMetrics as any).cpuUsage || 0).toFixed(1)}%
+                  {cpuUsage.toFixed(1)}%
                 </span>
               </div>
               <div className="w-full bg-neutral-200 dark:bg-neutral-700 rounded-full h-2">
                 <div
                   className={`h-2 rounded-full transition-all duration-300 ${
-                    ((systemMetrics as any).cpuUsage || 0) > 80
+                    cpuUsage > 80
                       ? "bg-error-500"
-                      : ((systemMetrics as any).cpuUsage || 0) > 60
+                      : cpuUsage > 60
                         ? "bg-warning-500"
                         : "bg-brand-500"
                   }`}
-                  style={{ width: `${(systemMetrics as any).cpuUsage || 0}%` }}
+                  style={{ width: `${cpuUsage}%` }}
                 />
               </div>
             </div>


### PR DESCRIPTION
## Summary
- remove explicit `any` usages in Base64 usage API route
- specify debug page state type for API response
- add extended system metrics type and cleanup usage in AnalyticsDashboard

## Testing
- `npm run validate` *(fails: code style issues)*
- `npm test` *(fails: test suite errors)*

------
https://chatgpt.com/codex/tasks/task_e_684099bf8a948331ad172cb8f82c526c