### PR TITLE
Fix missing Prisma CLI in Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -54,6 +54,8 @@ COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
 # Copy Prisma files and generate client
 COPY --from=builder /app/prisma ./prisma
 COPY --from=builder /app/node_modules/.prisma ./node_modules/.prisma
+# Include the Prisma CLI so migrations can run in production
+COPY --from=builder /app/node_modules/prisma ./node_modules/prisma
 
 USER nextjs
 


### PR DESCRIPTION
## Summary
- copy `node_modules/prisma` into final Docker image so migrations run

## Testing
- `npm run lint`
- `npm run type-check` *(fails: Object literal may only specify known properties, and 'mode' does not exist)*
- `npm test` *(fails: 9 test suites failed)*

------
https://chatgpt.com/codex/tasks/task_e_6840b72314bc83318c2e912e6f18b189