### PR TITLE
Add production migration script

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,6 +32,7 @@ Run `npm run env:validate` whenever you modify `.env.local`.
 ## Database utilities
 
 - `npm run db:migrate` – run migrations in development.
+- `npm run db:deploy` – apply migrations in production.
 - `npm run db:seed` – seed local data.
 
 ## Pull requests

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -58,6 +58,9 @@ Railway will automatically:
 - Run database migrations
 - Deploy the application
 
+If you choose Railway's Node environment instead of Docker, make sure to
+apply migrations with `npm run db:deploy` before starting the server.
+
 ### Environment Variables Reference
 
 | Variable               | Required | Description                   | Example                               |

--- a/README.md
+++ b/README.md
@@ -66,6 +66,15 @@ npm run test:a11y
 
 [![Deploy on Railway](https://railway.app/button.svg)](https://railway.app/new/template)
 
+If you use Railway's Node environment instead of Docker, be sure to run
+database migrations with:
+
+```bash
+npm run db:deploy
+```
+
+before starting the server.
+
 ### Docker Deployment
 
 ```bash

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "db:generate": "prisma generate",
     "db:push": "prisma db push",
     "db:migrate": "prisma migrate dev",
+    "db:deploy": "prisma migrate deploy",
     "db:studio": "prisma studio",
     "db:seed": "prisma db seed",
     "db:test-setup": "DATABASE_URL=file:./test.db npx prisma migrate deploy && DATABASE_URL=file:./test.db npx prisma generate",


### PR DESCRIPTION
## Summary
- add `db:deploy` script for Prisma migrations in production
- document using `db:deploy` for Railway
- list `db:deploy` in agent guidelines

## Testing
- `npm run format`
- `npm run validate` *(fails: `.env.local` file not found)*
- `npm test` *(fails: 10 failing tests)*


------
https://chatgpt.com/codex/tasks/task_e_6840c2f085b08331b370191bd8b9a6cc