### PR TITLE
Fix Playwright setup with SQLite schema

### DIFF
--- a/e2e/global-setup.ts
+++ b/e2e/global-setup.ts
@@ -25,18 +25,21 @@ async function globalSetup(config: FullConfig) {
       // Database file might not exist, which is fine
     }
 
-    // Set up E2E test database
+    // Set up E2E test database using the SQLite test schema
     console.log("🗄️  Setting up E2E test database...");
-    execSync("npx prisma migrate deploy", {
-      stdio: "pipe",
-      env: {
-        ...process.env,
-        DATABASE_URL: "file:./test-e2e.db",
+    execSync(
+      "npx prisma db push --force-reset --schema=prisma/schema.test.prisma",
+      {
+        stdio: "pipe",
+        env: {
+          ...process.env,
+          DATABASE_URL: "file:./test-e2e.db",
+        },
       },
-    });
+    );
 
-    // Generate Prisma client
-    execSync("npx prisma generate", {
+    // Generate Prisma client using the test schema
+    execSync("npx prisma generate --schema=prisma/schema.test.prisma", {
       stdio: "pipe",
     });
 

--- a/src/services/admin/relationshipService.ts
+++ b/src/services/admin/relationshipService.ts
@@ -86,9 +86,16 @@ export class RelationshipService
       }
 
       if (filters.search) {
+        const nameFilter: Record<string, unknown> = {
+          contains: filters.search,
+        };
+        if (process.env.DATABASE_PROVIDER !== "sqlite") {
+          nameFilter.mode = "insensitive";
+        }
+
         where.OR = [
-          { tool: { name: { contains: filters.search, mode: "insensitive" } } },
-          { tag: { name: { contains: filters.search, mode: "insensitive" } } },
+          { tool: { name: nameFilter } } as unknown as Prisma.ToolTagWhereInput,
+          { tag: { name: nameFilter } } as unknown as Prisma.ToolTagWhereInput,
         ];
       }
 


### PR DESCRIPTION
## Summary
- use the SQLite prisma schema during Playwright global setup
- handle StringFilter differences when DATABASE_PROVIDER=sqlite

## Testing
- `npm run format`
- `npm run lint`
- `npm run type-check`
- `npm test`
- `npx playwright test e2e/homepage.spec.ts --project=chromium --grep "should load homepage successfully"` *(fails: browsers not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68414b7885a08331861d6a3221da91b3