### PR TITLE
Add i18n foundation with next-intl

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ A modern, privacy-focused collection of essential computer tools built with Next
 - **Accessibility**: WCAG 2.1 AA compliant
 - **Performance**: Optimized for speed and efficiency
 - **Mobile-Friendly**: Responsive design for all devices
+- **Multilingual**: English and Spanish translations using next-intl
 
 ## 🛠️ Available Tools
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -17,6 +17,7 @@ const customJestConfig = {
   moduleNameMapper: {
     "^@/(.*)$": "<rootDir>/src/$1",
     "^@prisma/client$": "<rootDir>/node_modules/@prisma/client/index.js",
+    "^next-intl(.*)$": "<rootDir>/node_modules/next-intl/dist/cjs$1",
   },
 
   // Coverage configuration
@@ -73,7 +74,7 @@ const customJestConfig = {
 
   // Transform ignore patterns for node_modules
   transformIgnorePatterns: [
-    "/node_modules/",
+    "node_modules/(?!next-intl)",
     "^.+\\.module\\.(css|sass|scss)$",
   ],
 

--- a/messages/en.json
+++ b/messages/en.json
@@ -1,0 +1,11 @@
+{
+  "Header": {
+    "tools": "All Tools",
+    "about": "About"
+  },
+  "LocaleSwitcher": {
+    "label": "Language",
+    "en": "English",
+    "es": "Spanish"
+  }
+}

--- a/messages/es.json
+++ b/messages/es.json
@@ -1,0 +1,11 @@
+{
+  "Header": {
+    "tools": "Herramientas",
+    "about": "Acerca de"
+  },
+  "LocaleSwitcher": {
+    "label": "Idioma",
+    "en": "Inglés",
+    "es": "Español"
+  }
+}

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,4 +1,5 @@
 import type { NextConfig } from "next";
+import createNextIntlPlugin from "next-intl/plugin";
 
 const nextConfig: NextConfig = {
   /* Performance Optimizations */
@@ -122,4 +123,6 @@ const nextConfig: NextConfig = {
   },
 };
 
-export default nextConfig;
+const withNextIntl = createNextIntlPlugin();
+
+export default withNextIntl(nextConfig);

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,6 +35,7 @@
         "markdown-it-highlightjs": "^4.2.0",
         "markdown-it-task-lists": "^2.1.1",
         "next": "15.3.3",
+        "next-intl": "^4.1.0",
         "node-cache": "^5.1.2",
         "playwright": "^1.52.0",
         "postcss": "^8.5.4",
@@ -2780,6 +2781,66 @@
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
+    "node_modules/@formatjs/ecma402-abstract": {
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-2.3.4.tgz",
+      "integrity": "sha512-qrycXDeaORzIqNhBOx0btnhpD1c+/qFIHAN9znofuMJX6QBwtbrmlpWfD4oiUUD2vJUOIYFA/gYtg2KAMGG7sA==",
+      "license": "MIT",
+      "dependencies": {
+        "@formatjs/fast-memoize": "2.2.7",
+        "@formatjs/intl-localematcher": "0.6.1",
+        "decimal.js": "^10.4.3",
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@formatjs/ecma402-abstract/node_modules/@formatjs/intl-localematcher": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl-localematcher/-/intl-localematcher-0.6.1.tgz",
+      "integrity": "sha512-ePEgLgVCqi2BBFnTMWPfIghu6FkbZnnBVhO2sSxvLfrdFw7wCHAHiDoM2h4NRgjbaY7+B7HgOLZGkK187pZTZg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@formatjs/fast-memoize": {
+      "version": "2.2.7",
+      "resolved": "https://registry.npmjs.org/@formatjs/fast-memoize/-/fast-memoize-2.2.7.tgz",
+      "integrity": "sha512-Yabmi9nSvyOMrlSeGGWDiH7rf3a7sIwplbvo/dlz9WCIjzIQAfy1RMf4S0X3yG724n5Ghu2GmEl5NJIV6O9sZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@formatjs/icu-messageformat-parser": {
+      "version": "2.11.2",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-2.11.2.tgz",
+      "integrity": "sha512-AfiMi5NOSo2TQImsYAg8UYddsNJ/vUEv/HaNqiFjnI3ZFfWihUtD5QtuX6kHl8+H+d3qvnE/3HZrfzgdWpsLNA==",
+      "license": "MIT",
+      "dependencies": {
+        "@formatjs/ecma402-abstract": "2.3.4",
+        "@formatjs/icu-skeleton-parser": "1.8.14",
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@formatjs/icu-skeleton-parser": {
+      "version": "1.8.14",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-skeleton-parser/-/icu-skeleton-parser-1.8.14.tgz",
+      "integrity": "sha512-i4q4V4qslThK4Ig8SxyD76cp3+QJ3sAqr7f6q9VVfeGtxG9OhiAk3y9XF6Q41OymsKzsGQ6OQQoJNY4/lI8TcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@formatjs/ecma402-abstract": "2.3.4",
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@formatjs/intl-localematcher": {
+      "version": "0.5.10",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl-localematcher/-/intl-localematcher-0.5.10.tgz",
+      "integrity": "sha512-af3qATX+m4Rnd9+wHcjJ4w2ijq+rAVP3CCinJQvFv1kgSu1W6jypUmvleJxcewdxmutM8dmIRZFxO/IQBZmP2Q==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2"
+      }
+    },
     "node_modules/@heroicons/react": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@heroicons/react/-/react-2.2.0.tgz",
@@ -4510,6 +4571,12 @@
       "resolved": "https://registry.npmjs.org/@rushstack/eslint-patch/-/eslint-patch-1.11.0.tgz",
       "integrity": "sha512-zxnHvoMQVqewTJr/W4pKjF0bMGiKJv1WX7bSrkl46Hg0QjESbzBROWK0Wg4RphzSOS5Jiy7eFimmM3UgMrMZbQ==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@schummar/icu-type-parser": {
+      "version": "1.21.5",
+      "resolved": "https://registry.npmjs.org/@schummar/icu-type-parser/-/icu-type-parser-1.21.5.tgz",
+      "integrity": "sha512-bXHSaW5jRTmke9Vd0h5P7BtWZG9Znqb8gSDxZnxaGSJnGwPLDPfS+3g0BKzeWqzgZPsIVZkM7m2tbo18cm5HBw==",
       "license": "MIT"
     },
     "node_modules/@sinclair/typebox": {
@@ -7611,7 +7678,6 @@
       "version": "10.5.0",
       "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.5.0.tgz",
       "integrity": "sha512-8vDa8Qxvr/+d94hSh5P3IJwI5t8/c0KsMp+g8bNw9cY2icONa5aPfvKeieW1WlG0WQYwwhJ7mjui2xtiePQSXw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/decode-named-character-reference": {
@@ -9532,6 +9598,18 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/intl-messageformat": {
+      "version": "10.7.16",
+      "resolved": "https://registry.npmjs.org/intl-messageformat/-/intl-messageformat-10.7.16.tgz",
+      "integrity": "sha512-UmdmHUmp5CIKKjSoE10la5yfU+AYJAaiYLsodbjL4lji83JNvgOQUjGaGhGrpFCb0Uh7sl7qfP1IyILa8Z40ug==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@formatjs/ecma402-abstract": "2.3.4",
+        "@formatjs/fast-memoize": "2.2.7",
+        "@formatjs/icu-messageformat-parser": "2.11.2",
+        "tslib": "^2.8.0"
       }
     },
     "node_modules/is-alphabetical": {
@@ -12871,6 +12949,15 @@
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "license": "MIT"
     },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/next": {
       "version": "15.3.3",
       "resolved": "https://registry.npmjs.org/next/-/next-15.3.3.tgz",
@@ -12921,6 +13008,33 @@
           "optional": true
         },
         "sass": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/next-intl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/next-intl/-/next-intl-4.1.0.tgz",
+      "integrity": "sha512-JNJRjc7sdnfUxhZmGcvzDszZ60tQKrygV/VLsgzXhnJDxQPn1cN2rVpc53adA1SvBJwPK2O6Sc6b4gYSILjCzw==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/amannn"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@formatjs/intl-localematcher": "^0.5.4",
+        "negotiator": "^1.0.0",
+        "use-intl": "^4.1.0"
+      },
+      "peerDependencies": {
+        "next": "^12.0.0 || ^13.0.0 || ^14.0.0 || ^15.0.0",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || >=19.0.0-rc <19.0.0 || ^19.0.0",
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
           "optional": true
         }
       }
@@ -16019,6 +16133,20 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/use-intl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/use-intl/-/use-intl-4.1.0.tgz",
+      "integrity": "sha512-mQvDYFvoGn+bm/PWvlQOtluKCknsQ5a9F1Cj0hMfBjMBVTwnOqLPd6srhjvVdEQEQFVyHM1PfyifKqKYb11M9Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@formatjs/fast-memoize": "^2.2.0",
+        "@schummar/icu-type-parser": "1.21.5",
+        "intl-messageformat": "^10.5.14"
+      },
+      "peerDependencies": {
+        "react": "^17.0.0 || ^18.0.0 || >=19.0.0-rc <19.0.0 || ^19.0.0"
       }
     },
     "node_modules/use-sync-external-store": {

--- a/package.json
+++ b/package.json
@@ -89,6 +89,7 @@
     "markdown-it-highlightjs": "^4.2.0",
     "markdown-it-task-lists": "^2.1.1",
     "next": "15.3.3",
+    "next-intl": "^4.1.0",
     "node-cache": "^5.1.2",
     "playwright": "^1.52.0",
     "postcss": "^8.5.4",

--- a/src/app/api/locale/route.ts
+++ b/src/app/api/locale/route.ts
@@ -1,0 +1,16 @@
+import { NextResponse } from "next/server";
+import { Locale, locales } from "@/i18n/config";
+
+export async function POST(request: Request) {
+  const { locale } = await request.json();
+  if (!locales.includes(locale as Locale)) {
+    return NextResponse.json({ error: "Invalid locale" }, { status: 400 });
+  }
+
+  const response = NextResponse.json({ success: true });
+  response.cookies.set("NEXT_LOCALE", locale, {
+    path: "/",
+    maxAge: 60 * 60 * 24 * 365,
+  });
+  return response;
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,7 +1,10 @@
 import type { Metadata } from "next";
 import { Inter, JetBrains_Mono } from "next/font/google";
 import { Header, Footer } from "@/components/layout";
+import { LocaleSwitcher } from "@/components";
 import { WebVitals } from "@/components/ui";
+import { NextIntlClientProvider } from "next-intl";
+import { getLocale, getMessages } from "next-intl/server";
 import "./globals.css";
 
 const inter = Inter({
@@ -76,13 +79,19 @@ export const metadata: Metadata = {
   },
 };
 
-export default function RootLayout({
+export default async function RootLayout({
   children,
 }: Readonly<{
   children: React.ReactNode;
 }>) {
+  const locale = await getLocale();
+  const messages = await getMessages();
+
   return (
-    <html lang="en" className={`${inter.variable} ${jetbrainsMono.variable}`}>
+    <html
+      lang={locale}
+      className={`${inter.variable} ${jetbrainsMono.variable}`}
+    >
       <head>
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
         <meta name="apple-mobile-web-app-capable" content="yes" />
@@ -111,11 +120,16 @@ export default function RootLayout({
           aria-hidden="true"
         />
 
-        <Header />
+        <NextIntlClientProvider locale={locale} messages={messages}>
+          <Header />
+          <div className="absolute top-2 right-4">
+            <LocaleSwitcher />
+          </div>
 
-        <main className="flex-grow relative">{children}</main>
+          <main className="flex-grow relative">{children}</main>
 
-        <Footer />
+          <Footer />
+        </NextIntlClientProvider>
       </body>
     </html>
   );

--- a/src/components/LocaleSwitcher.tsx
+++ b/src/components/LocaleSwitcher.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+import { useLocale, useTranslations } from "next-intl";
+import { useTransition } from "react";
+
+export default function LocaleSwitcher() {
+  const t = useTranslations("LocaleSwitcher");
+  const locale = useLocale();
+  const [isPending, startTransition] = useTransition();
+
+  const onChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    const value = e.target.value;
+    startTransition(async () => {
+      await fetch("/api/locale", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ locale: value }),
+      });
+      window.location.reload();
+    });
+  };
+
+  return (
+    <label className="inline-flex items-center gap-2">
+      <span className="sr-only">{t("label")}</span>
+      <select
+        onChange={onChange}
+        defaultValue={locale}
+        disabled={isPending}
+        className="border rounded p-1 text-sm"
+      >
+        <option value="en">{t("en")}</option>
+        <option value="es">{t("es")}</option>
+      </select>
+    </label>
+  );
+}

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -12,3 +12,4 @@ export * from "./tools";
 
 // Error Components
 export * from "./errors";
+export { default as LocaleSwitcher } from "./LocaleSwitcher";

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -10,6 +10,7 @@ import {
 } from "@heroicons/react/24/outline";
 
 import { cn } from "@/utils";
+import { useTranslations } from "next-intl";
 
 export interface HeaderProps {
   className?: string;
@@ -20,6 +21,7 @@ export function Header({ className }: HeaderProps) {
   const [searchQuery, setSearchQuery] = useState("");
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
   const router = useRouter();
+  const t = useTranslations("Header");
 
   useEffect(() => {
     const handleScroll = () => {
@@ -153,7 +155,7 @@ export function Header({ className }: HeaderProps) {
                     "hover:bg-background-secondary hover:text-brand-600",
                   )}
                 >
-                  All Tools
+                  {t("tools")}
                 </Link>
                 <Link
                   href="/about"
@@ -162,7 +164,7 @@ export function Header({ className }: HeaderProps) {
                     "hover:bg-background-secondary hover:text-brand-600",
                   )}
                 >
-                  About
+                  {t("about")}
                 </Link>
               </nav>
             </div>
@@ -285,7 +287,7 @@ export function Header({ className }: HeaderProps) {
                     )}
                     onClick={toggleMobileMenu}
                   >
-                    <span>All Tools</span>
+                    <span>{t("tools")}</span>
                     <span className="text-foreground-secondary text-sm">
                       Browse collection
                     </span>
@@ -301,7 +303,7 @@ export function Header({ className }: HeaderProps) {
                     )}
                     onClick={toggleMobileMenu}
                   >
-                    <span>About</span>
+                    <span>{t("about")}</span>
                     <span className="text-foreground-secondary text-sm">
                       Learn more
                     </span>

--- a/src/i18n/config.ts
+++ b/src/i18n/config.ts
@@ -1,0 +1,3 @@
+export const locales = ["en", "es"] as const;
+export type Locale = (typeof locales)[number];
+export const defaultLocale: Locale = "en";

--- a/src/i18n/request.ts
+++ b/src/i18n/request.ts
@@ -1,0 +1,11 @@
+import { getRequestConfig } from "next-intl/server";
+import { getUserLocale } from "@/services/locale";
+
+export default getRequestConfig(async () => {
+  const locale = await getUserLocale();
+
+  return {
+    locale,
+    messages: (await import(`../../messages/${locale}.json`)).default,
+  };
+});

--- a/src/services/locale.ts
+++ b/src/services/locale.ts
@@ -1,0 +1,14 @@
+"use server";
+
+import { cookies } from "next/headers";
+import { Locale, defaultLocale } from "@/i18n/config";
+
+const COOKIE_NAME = "NEXT_LOCALE";
+
+export async function getUserLocale(): Promise<Locale> {
+  return ((await cookies()).get(COOKIE_NAME)?.value as Locale) ?? defaultLocale;
+}
+
+export async function setUserLocale(locale: Locale) {
+  (await cookies()).set(COOKIE_NAME, locale, { path: "/" });
+}


### PR DESCRIPTION
## Summary
- integrate next-intl plugin
- add English and Spanish messages
- implement locale cookies and API route
- add locale switcher component
- update Header to use translations
- expose translations in layout
- document multilingual support
- configure Jest to transform next-intl

## Testing
- `npm run format`
- `npm run validate` *(fails: ❌ .env.local file not found)*
- `npm test` *(fails: Could not locate module next-intl mapped in tests)*

------
https://chatgpt.com/codex/tasks/task_e_6841dca00c24833182e48bd6c07a9078