### PR TITLE
Fix missing root locale routing

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,0 +1,29 @@
+import { Header, Footer } from "@/components/layout";
+import { LocaleSwitcher } from "@/components";
+import { WebVitals } from "@/components/ui";
+import { NextIntlClientProvider } from "next-intl";
+import { getMessages, getLocale } from "next-intl/server";
+import { locales, defaultLocale } from "@/i18n/config";
+import HomePage from "./[locale]/page";
+
+export default async function IndexPage() {
+  let locale = await getLocale();
+  if (!locales.includes(locale as any)) {
+    locale = defaultLocale;
+  }
+  const messages = await getMessages({ locale });
+
+  return (
+    <NextIntlClientProvider locale={locale} messages={messages}>
+      <WebVitals debug={process.env.NODE_ENV === "development"} />
+      <Header />
+      <div className="absolute top-2 right-4">
+        <LocaleSwitcher />
+      </div>
+      <main className="flex-grow relative">
+        <HomePage />
+      </main>
+      <Footer />
+    </NextIntlClientProvider>
+  );
+}


### PR DESCRIPTION
## Summary
- add `/` index page that detects the preferred locale and renders the same home page used for locale prefixed routes

## Testing
- `npm run validate` *(fails: npm-run-all not found)*

------
https://chatgpt.com/codex/tasks/task_e_68435c46808883319026a48b80c10e80