### PR TITLE
Move locale switcher to footer

### DIFF
--- a/src/components/LocaleSwitcher.tsx
+++ b/src/components/LocaleSwitcher.tsx
@@ -1,9 +1,8 @@
 "use client";
 
 import { useLocale, useTranslations } from "next-intl";
-import { locales, localeNames } from "@/i18n/config";
-import { useTransition } from "react";
-import { ChevronDownIcon } from "@heroicons/react/24/solid";
+import { locales, localeNames, Locale } from "@/i18n/config";
+import { useTransition, useState } from "react";
 import { cn } from "@/utils";
 import { usePathname, useRouter } from "next/navigation";
 
@@ -11,12 +10,33 @@ export default function LocaleSwitcher() {
   // Use the same namespace as the existing layout translations
   const t = useTranslations("components.layout.localeSwitcher");
   const locale = useLocale();
+  const [selectedLocale, setSelectedLocale] = useState(locale);
   const pathname = usePathname();
   const router = useRouter();
   const [isPending, startTransition] = useTransition();
 
+  const localeFlags: Record<Locale, string> = {
+    en: "🇺🇸",
+    es: "🇪🇸",
+    zh: "🇨🇳",
+    hi: "🇮🇳",
+    pt: "🇧🇷",
+    ru: "🇷🇺",
+    ja: "🇯🇵",
+    de: "🇩🇪",
+    fr: "🇫🇷",
+    ko: "🇰🇷",
+    it: "🇮🇹",
+    tr: "🇹🇷",
+    pl: "🇵🇱",
+    nl: "🇳🇱",
+    vi: "🇻🇳",
+    uk: "🇺🇦",
+  };
+
   const onChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
-    const value = e.target.value;
+    const value = e.target.value as Locale;
+    setSelectedLocale(value);
     startTransition(async () => {
       // Persist locale preference in a cookie for future visits
       await fetch("/api/locale", {
@@ -49,7 +69,7 @@ export default function LocaleSwitcher() {
       <select
         id="locale-switcher"
         onChange={onChange}
-        defaultValue={locale}
+        value={selectedLocale}
         disabled={isPending}
         className={cn(
           "input-field pr-10 cursor-pointer min-h-[44px] font-medium w-auto", // design token utilities
@@ -69,11 +89,13 @@ export default function LocaleSwitcher() {
         {t("current", { locale })}
       </span>
 
-      {/* Custom dropdown icon */}
-      <ChevronDownIcon
-        className="absolute right-4 top-1/2 h-4 w-4 -translate-y-1/2 text-foreground-secondary pointer-events-none"
+      {/* Custom dropdown icon showing the current locale flag */}
+      <span
+        className="absolute right-4 top-1/2 -translate-y-1/2 pointer-events-none"
         aria-hidden="true"
-      />
+      >
+        {localeFlags[selectedLocale as Locale]}
+      </span>
     </div>
   );
 }

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -7,6 +7,7 @@ import {
   SparklesIcon,
 } from "@heroicons/react/24/outline";
 import { cn } from "@/utils";
+import LocaleSwitcher from "@/components/LocaleSwitcher";
 
 export interface FooterProps {
   className?: string;
@@ -181,6 +182,10 @@ export function Footer({ className }: FooterProps) {
         >
           <div className="flex items-center gap-2 text-base text-foreground-secondary">
             <span>&copy; {currentYear} tool-chest. All rights reserved.</span>
+          </div>
+
+          <div className="mt-2 sm:mt-0">
+            <LocaleSwitcher />
           </div>
 
           <div className="flex items-center gap-2 text-base text-foreground-secondary">

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -8,7 +8,6 @@ import {
   Bars3Icon,
   XMarkIcon,
 } from "@heroicons/react/24/outline";
-import LocaleSwitcher from "@/components/LocaleSwitcher";
 
 import { cn } from "@/utils";
 import { useTranslations } from "next-intl";
@@ -168,9 +167,6 @@ export function Header({ className }: HeaderProps) {
                   {t("navigation.about")}
                 </Link>
               </nav>
-
-              {/* Locale Switcher for desktop */}
-              <LocaleSwitcher />
             </div>
 
             {/* Mobile Controls with enhanced touch targets */}
@@ -314,11 +310,6 @@ export function Header({ className }: HeaderProps) {
                   </Link>
                 </div>
               </nav>
-
-              {/* Mobile Locale Switcher */}
-              <div className="mt-6">
-                <LocaleSwitcher />
-              </div>
 
               {/* Mobile menu footer with additional context */}
               <div className="mt-8 pt-6 border-t border-border-secondary">


### PR DESCRIPTION
## Summary
- move locale switcher from header into the footer
- show flag of selected locale in place of the arrow icon

## Testing
- `npm run validate` *(fails: DatabaseTranslationService test fails)*

------
https://chatgpt.com/codex/tasks/task_e_68505a1af0148331ace0d818cc03d73d