### PR TITLE
fix: ensure PDF template defaults

### DIFF
--- a/src/components/tools/MarkdownToPdfTool.tsx
+++ b/src/components/tools/MarkdownToPdfTool.tsx
@@ -421,6 +421,10 @@ export function MarkdownToPdfTool() {
           syntaxHighlighting: {
             ...DEFAULT_PDF_STYLING.syntaxHighlighting,
             ...template.stylingOptions.syntaxHighlighting,
+            theme:
+              template.stylingOptions.syntaxHighlighting?.theme ??
+              DEFAULT_PDF_STYLING.syntaxHighlighting?.theme ??
+              "github",
             enabled:
               template.stylingOptions.syntaxHighlighting?.enabled ??
               DEFAULT_PDF_STYLING.syntaxHighlighting?.enabled ??
@@ -429,6 +433,18 @@ export function MarkdownToPdfTool() {
           pageNumbers: {
             ...DEFAULT_PDF_STYLING.pageNumbers,
             ...template.stylingOptions.pageNumbers,
+            position:
+              template.stylingOptions.pageNumbers?.position ??
+              DEFAULT_PDF_STYLING.pageNumbers?.position ??
+              "footer",
+            alignment:
+              template.stylingOptions.pageNumbers?.alignment ??
+              DEFAULT_PDF_STYLING.pageNumbers?.alignment ??
+              "center",
+            format:
+              template.stylingOptions.pageNumbers?.format ??
+              DEFAULT_PDF_STYLING.pageNumbers?.format ??
+              "page-of-total",
             enabled:
               template.stylingOptions.pageNumbers?.enabled ??
               DEFAULT_PDF_STYLING.pageNumbers?.enabled ??

--- a/src/components/tools/PdfCustomizationPanel.tsx
+++ b/src/components/tools/PdfCustomizationPanel.tsx
@@ -120,22 +120,58 @@ export function PdfCustomizationPanel({
       header: {
         ...DEFAULT_PDF_STYLING.header,
         ...template.stylingOptions.header,
+        enabled:
+          template.stylingOptions.header?.enabled ??
+          DEFAULT_PDF_STYLING.header?.enabled ??
+          false,
       },
       footer: {
         ...DEFAULT_PDF_STYLING.footer,
         ...template.stylingOptions.footer,
+        enabled:
+          template.stylingOptions.footer?.enabled ??
+          DEFAULT_PDF_STYLING.footer?.enabled ??
+          false,
       },
       tableOfContents: {
         ...DEFAULT_PDF_STYLING.tableOfContents,
         ...template.stylingOptions.tableOfContents,
+        enabled:
+          template.stylingOptions.tableOfContents?.enabled ??
+          DEFAULT_PDF_STYLING.tableOfContents?.enabled ??
+          false,
       },
       syntaxHighlighting: {
         ...DEFAULT_PDF_STYLING.syntaxHighlighting,
         ...template.stylingOptions.syntaxHighlighting,
+        theme:
+          template.stylingOptions.syntaxHighlighting?.theme ??
+          DEFAULT_PDF_STYLING.syntaxHighlighting?.theme ??
+          "github",
+        enabled:
+          template.stylingOptions.syntaxHighlighting?.enabled ??
+          DEFAULT_PDF_STYLING.syntaxHighlighting?.enabled ??
+          false,
       },
       pageNumbers: {
         ...DEFAULT_PDF_STYLING.pageNumbers,
         ...template.stylingOptions.pageNumbers,
+        position:
+          template.stylingOptions.pageNumbers?.position ??
+          DEFAULT_PDF_STYLING.pageNumbers?.position ??
+          "footer",
+        alignment:
+          template.stylingOptions.pageNumbers?.alignment ??
+          DEFAULT_PDF_STYLING.pageNumbers?.alignment ??
+          "center",
+        format:
+          template.stylingOptions.pageNumbers?.format ??
+          DEFAULT_PDF_STYLING.pageNumbers?.format ??
+          "page-of-total",
+        enabled:
+          template.stylingOptions.pageNumbers?.enabled ??
+          DEFAULT_PDF_STYLING.pageNumbers?.enabled ??
+          false,
       },
       accessibility: {
         ...DEFAULT_PDF_STYLING.accessibility,


### PR DESCRIPTION
## Summary
- ensure syntax highlighting and page number defaults are applied when merging PDF templates
- guarantee PdfCustomizationPanel sets required template options

## Testing
- `npm run lint:fix`
- `npm run validate` *(fails: Missing translation keys referenced in code)*
- `npm test`
- `npm run build` *(fails: Can't reach database server)*

------
https://chatgpt.com/codex/tasks/task_e_6895fa15fdb88331b81b8042877f49b5