### PR TITLE
Fix tool usage tracking

### DIFF
--- a/src/app/api/tools/[slug]/usage/route.ts
+++ b/src/app/api/tools/[slug]/usage/route.ts
@@ -1,0 +1,30 @@
+import { NextRequest, NextResponse } from "next/server";
+import { serviceFactory } from "@/services/core/serviceFactory";
+
+export async function POST(
+  _request: NextRequest,
+  { params }: { params: { slug: string } },
+) {
+  try {
+    const { slug } = params;
+    const toolService = serviceFactory.getToolService();
+    await toolService.recordToolUsage(slug);
+
+    return NextResponse.json({
+      success: true,
+      message: "Usage recorded successfully",
+      timestamp: new Date().toISOString(),
+    });
+  } catch (error) {
+    console.error("Error recording tool usage:", error);
+    return NextResponse.json(
+      {
+        success: false,
+        error: "Failed to record tool usage",
+        message: error instanceof Error ? error.message : "Unknown error",
+        timestamp: new Date().toISOString(),
+      },
+      { status: 500 },
+    );
+  }
+}

--- a/src/hooks/__tests__/useToolsWithState.test.ts
+++ b/src/hooks/__tests__/useToolsWithState.test.ts
@@ -131,8 +131,10 @@ describe("useToolsWithState", () => {
       await result.current.actions.recordUsage("t1");
     });
 
-    // No external fetch is triggered; ensure state updates occurred
-    expect(mutateMock).toHaveBeenCalled();
+    expect(fetchMock).toHaveBeenCalledWith("/api/tools/t1/usage", {
+      method: "POST",
+    });
+    expect(mutateMock).toHaveBeenCalledTimes(2);
     expect(mockMutate).toHaveBeenCalledWith("/api/tools?popular=true");
   });
 
@@ -298,9 +300,11 @@ describe("useToolsWithState", () => {
       await result.current.actions.recordUsage("t1");
     });
 
-    // No server call means no failure; optimistic update followed by sync
+    expect(fetchMock).toHaveBeenCalledWith("/api/tools/t1/usage", {
+      method: "POST",
+    });
     expect(mutateMock).toHaveBeenCalledTimes(2);
-    expect(consoleErrorSpy).not.toHaveBeenCalled();
+    expect(consoleErrorSpy).toHaveBeenCalled();
 
     consoleErrorSpy.mockRestore();
   });

--- a/src/hooks/useToolsWithState.ts
+++ b/src/hooks/useToolsWithState.ts
@@ -159,8 +159,12 @@ export function useToolsWithState(): ToolsWithStateResult {
           // Update local cache optimistically
           await mutateTools(optimisticData, false);
         }
-
-        // Raw usage endpoint removed – skip server call
+        const response = await fetch(`/api/tools/${toolSlug}/usage`, {
+          method: "POST",
+        });
+        if (!response.ok) {
+          throw new Error("Failed to record usage");
+        }
         await mutateTools();
         await mutate("/api/tools?popular=true");
       } catch (error) {
@@ -263,8 +267,12 @@ export function useToolWithUsage(slug: string) {
         };
         await mutateTool(optimisticData, false);
       }
-
-      // Raw usage endpoint removed – skip server call
+      const response = await fetch(`/api/tools/${slug}/usage`, {
+        method: "POST",
+      });
+      if (!response.ok) {
+        throw new Error("Failed to record usage");
+      }
       await mutateTool();
       await mutate("/api/tools?popular=true");
     } catch (error) {


### PR DESCRIPTION
## Summary
- add endpoint to record tool usage
- update tool hooks to call usage endpoint
- cover usage tracking with tests

## Testing
- `npm run format`
- `npm run validate`


------
https://chatgpt.com/codex/tasks/task_e_689f0f68521883319e5eae6a081bb2ac